### PR TITLE
Use global random engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,8 @@ ModEvent.Send(handle)
 * **Use dynamic effects** for temporary, mod-specific, or rare effects.
 
 See script headers and `sla_pluginbase.psc` for more advanced usage and plugin integration details.
+
+### Randomness
+
+The initial arousal update uses a global `std::mt19937` engine seeded during plugin initialization.  
+With the default seed from `std::random_device` the offset remains nondeterministic, but providing a fixed seed in `InitializeRandomEngine` will make it deterministic across runs.

--- a/include/ArousalData.h
+++ b/include/ArousalData.h
@@ -1,9 +1,12 @@
 #pragma once
 #include "SerializationHelper.h"
 #include <SKSE/SKSE.h>
+#include <random>
 
 namespace SLA {
     extern uint32_t staticEffectCount;
+    extern std::mt19937 randomEngine;
+    void InitializeRandomEngine();
     struct ArousalEffectGroup {
         ArousalEffectGroup() : value(0.f) {}
         std::vector<uint32_t> staticEffectIds;

--- a/src/ArousalData.cpp
+++ b/src/ArousalData.cpp
@@ -3,6 +3,12 @@
 
 namespace SLA {
     uint32_t staticEffectCount = 0;
+    std::mt19937 randomEngine;
+
+    void InitializeRandomEngine() {
+        std::random_device rd;
+        randomEngine.seed(rd());
+    }
 
     void ArousalData::OnRegisterStaticEffect() {
         staticEffects.emplace_back();
@@ -207,10 +213,8 @@ namespace SLA {
 
     void ArousalData::UpdateSingleActorArousal(RE::Actor* who, float GameDaysPassed) {
         if (!lastUpdate) {
-            std::random_device rd;
-            std::default_random_engine gen{rd()};
             std::normal_distribution<> d{0.5, 2.0};
-            float randomTimeDiff = std::abs(float(d(gen)));
+            float randomTimeDiff = std::abs(float(d(randomEngine)));
             lastUpdate = GameDaysPassed - randomTimeDiff;
         }
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,6 +1,7 @@
 #include "Papyrus.h"
 #include <stddef.h>
 #include <ArousalManager.h>
+#include <ArousalData.h>
 
 using namespace RE::BSScript;
 using namespace SKSE;
@@ -58,6 +59,7 @@ SKSEPluginLoad(const LoadInterface* skse) {
     log::info("{} {} is loading...", plugin->GetName(), version);
 
     Init(skse);
+    SLA::InitializeRandomEngine();
     InitializeSerialization();
     InitializePapyrus();
 


### PR DESCRIPTION
## Summary
- add shared random engine and initialization function
- use that engine for initial offset
- expose initialization in main entry
- document how to get deterministic behavior

## Testing
- `cmake -B build -S .` *(fails: Could not find CommonLibSSE)*

------
https://chatgpt.com/codex/tasks/task_b_68448b78541083208e229b7d97e8acd6