### PR TITLE
Fix duplicated MCM options

### DIFF
--- a/dist/Core/Source/Scripts/sla_pluginbase.psc
+++ b/dist/Core/Source/Scripts/sla_pluginbase.psc
@@ -84,8 +84,17 @@ endFunction
 int numberOfOptions = 0
 
 function ClearOptions()
-	StorageUtil.ClearAllPrefix("SLAroused.MCM." + self.name)
-	numberOfOptions = 0
+        string prefix = "SLAroused.MCM." + self.name + "."
+        int i = StorageUtil.StringListCount(main, "SLAroused.MCM.Options") - 1
+        while i >= 0
+                string val = StorageUtil.StringListGet(main, "SLAroused.MCM.Options", i)
+                if val != "" && val.Find(prefix) == 0
+                        StorageUtil.StringListRemoveAt(main, "SLAroused.MCM.Options", i)
+                        StorageUtil.ClearAllPrefix(val)
+                endIf
+                i -= 1
+        endWhile
+        numberOfOptions = 0
 endFunction
 
 int function GetNumberOfOptions()


### PR DESCRIPTION
## Summary
- prevent `sla_pluginbase` from leaving old MCM data

## Testing
- `cmake -B build -S . -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find package `CommonLibSSE`)*

------
https://chatgpt.com/codex/tasks/task_b_6844939e81488320a6cbc39504692f17