### PR TITLE
Fix plugin loop safety

### DIFF
--- a/dist/Core/Source/Scripts/slamainscr.psc
+++ b/dist/Core/Source/Scripts/slamainscr.psc
@@ -789,15 +789,17 @@ function ForceUpdateActor(Actor who)
 
     int i = 0
     if updatePlugins
-        i = updatePlugins.Length    
+        i = updatePlugins.Length
     endif
-	
-	while i > 0
-		i -= 1
-		sla_PluginBase plugin = updatePlugins[i]
-		plugin.UpdateActor(who, false)
-		plugin.UpdateActor(none, false)
-	endWhile
+
+    while i > 0
+        i -= 1
+        sla_PluginBase plugin = updatePlugins[i]
+        if plugin
+            plugin.UpdateActor(who, false)
+            plugin.UpdateActor(none, false)
+        endIf
+    endWhile
     UpdateSingleActorArousal(who)
 endFunction
 


### PR DESCRIPTION
## Summary
- guard plugin loop in `ForceUpdateActor`

## Testing
- `cmake -B build` *(fails: Could not find CommonLibSSEConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_b_6845970d03948320be676f7539996038