### PR TITLE
fix: fastsin always returns 0 in ArousalData.cpp (frozen timed arousal at 50)

### DIFF
--- a/include/ArousalData.h
+++ b/include/ArousalData.h
@@ -62,14 +62,31 @@ namespace SLA {
                 for (uint32_t k = 0; k < grpEntiryCount; ++k) {
                     uint32_t effIdx = ReadDataHelper<uint32_t>(intfc, length);
                     grp->staticEffectIds.emplace_back(effIdx);
-                    staticEffectGroups[effIdx] = grp;
+                    // Defer staticEffectGroups assignment until after dead-member check below
                 }
                 grp->value = ReadDataHelper<float>(intfc, length);
                 if (std::abs(grp->value) > 10000.f) {
                     SKSE::log::info("Possibly corrupted data reseting to zero");
                     grp->value = 0.f;
                 }
-                groupsToUpdate.emplace_back(std::move(grp));
+                // Discard groups where any member has function==0 (sine stopped in a prior session).
+                // Reset param/intAux so Papyrus detects the actor via cycleParam < 1.0 and calls
+                // UpdateDenialCycle to re-establish the group on the next scan.
+                bool hasDeadMember = false;
+                for (uint32_t effIdx : grp->staticEffectIds) {
+                    if (staticEffects[effIdx].function == 0) {
+                        staticEffects[effIdx].param = 0.f;
+                        staticEffects[effIdx].intAux = 0;
+                        staticEffects[effIdx].value = 0.f;
+                        hasDeadMember = true;
+                    }
+                }
+                if (!hasDeadMember) {
+                    for (uint32_t effIdx : grp->staticEffectIds) {
+                        staticEffectGroups[effIdx] = grp;
+                    }
+                    groupsToUpdate.emplace_back(std::move(grp));
+                }
             }
             count = ReadDataHelper<uint32_t>(intfc, length);
             for (uint32_t j = 0; j < count; ++j) staticEffectsToUpdate.insert(ReadDataHelper<uint32_t>(intfc, length));

--- a/src/ArousalData.cpp
+++ b/src/ArousalData.cpp
@@ -6,6 +6,7 @@ namespace SLA {
     std::mt19937 randomEngine;
 
     void InitializeRandomEngine() {
+        BuildSinCosTable();  // fill this TU's copy of fast_cossin_table (anonymous namespace in header = per-TU table)
         std::random_device rd;
         randomEngine.seed(rd());
     }


### PR DESCRIPTION
## Summary

- `CosSin.h` declares `fast_cossin_table` inside an anonymous namespace, so each `.cpp` that includes it gets its own zero-initialized copy. `BuildSinCosTable()` was only called in `Papyrus.cpp`, leaving `ArousalData.cpp`'s copy permanently zeroed — `fastsin()` returned `0` for every input in that TU.
- For the denial/chastity timed arousal system, `timedCycleEff` uses function 3 (sine oscillator): `value = (fastsin(seed + lastUpdate * param) + 1.0) * limit`. With `fastsin=0` this collapses to `0.5` always. Once `timedEff` reaches its max (100), `group->value = 100 * 0.5 = 50` — frozen forever. Affected actors showed exactly 50 arousal every scan with no variation.

## Changes

**`src/ArousalData.cpp`** — call `BuildSinCosTable()` in `InitializeRandomEngine()` so `ArousalData.cpp`'s lookup table is populated at DLL load time (+1 line)

**`include/ArousalData.h`** — on cosave load, discard groups where any member has `function==0` (sine stopped in a prior session due to this bug). Reset member params to `0` so Papyrus detects them via `cycleParam < 1.0` and calls `UpdateDenialCycle` to rebuild the group on the next scan.

## Test plan

- [ ] Load a save with a long-denied actor — timed arousal contribution should oscillate rather than sit at exactly 50
- [ ] Verify `timedCycleEff.value` varies per actor and over time (no longer constant 0.5)
- [ ] Verify no regression for actors without denial effects

🤖 Generated with [Claude Code](https://claude.ai/claude-code)