### PR TITLE
fix: MCM blank text values and related Papyrus bugs

### DIFF
--- a/dist/Core/Source/Scripts/sla_defaultplugin.psc
+++ b/dist/Core/Source/Scripts/sla_defaultplugin.psc
@@ -234,7 +234,7 @@ state Installed
 			endIf
 
 			if useDenialCycle
-				if GetArousalEffectFncAux(currentObserver, timedCycleEff) != 1
+				if GetArousalEffectFncAux(currentObserver, timedCycleEff) != 1 || GetArousalEffectFncParam(currentObserver, timedCycleEff) < 1.0
 					UpdateDenialCycle(currentObserver)
 				endIf
 			elseIf GetArousalEffectFncAux(currentObserver, timedCycleEff) == 1

--- a/dist/Core/Source/Scripts/sla_pluginbase.psc
+++ b/dist/Core/Source/Scripts/sla_pluginbase.psc
@@ -28,6 +28,10 @@ endfunction
 event On_sla_Int_PlayerLoadsGame(string eventName, string strArg, float numArg, Form sender)
 	slax.info("sla_PluginBase - On_sla_Int_PlayerLoadsGame: " + name )
 	UpdatePluginState(false)
+	if isEnabled
+		ClearOptions()
+		AddOptions()
+	endIf
 endEvent
 
 function UpdatePluginState(bool forced)
@@ -62,7 +66,7 @@ endFunction
 function DisablePlugin()
 	{To be implemented by plugin}
 	UnregisterForLOSUpdates()
-	main.SetPluginUpdateEvents(self, true)
+	main.SetPluginUpdateEvents(self, false)
 endFunction
 
 function Update(Actor[] actors, Actor[] nakedActors)
@@ -133,7 +137,7 @@ int function AddOption(string category, string title, string description, float 
 endFunction
 
 function SetOptionDefault(int option, float defaultValue)
-	string id = "SLAroused.MCM." + self.name + "." + numberOfOptions + ".Default"
+	string id = "SLAroused.MCM." + self.name + "." + option + ".Default"
 	StorageUtil.SetFloatValue(main, id, defaultValue)
 endFunction
 

--- a/dist/Core/Source/Scripts/slaconfigscr.psc
+++ b/dist/Core/Source/Scripts/slaconfigscr.psc
@@ -352,7 +352,7 @@ Event OnConfigClose()
     slaMain.updateFrequency = cellScanFreq
 	slaMain.setUpdateFrequency(cellScanFreq)
     
-    StorageUtil.ClearObjIntValuePrefix(none, "SLAroused.MCM.OID.")
+    StorageUtil.ClearObjIntValuePrefix(self, "SLAroused.MCM.OID.")
 
 EndEvent
 
@@ -361,7 +361,7 @@ Event OnPageReset(String page)
     if !slaMain
         slaMain = Quest.GetQuest("sla_Main") as slaMainScr
     endif
-    StorageUtil.ClearObjIntValuePrefix(none, "SLAroused.MCM.OID.")
+    StorageUtil.ClearObjIntValuePrefix(self, "SLAroused.MCM.OID.")
 
     pageName = page
 	; Load custom logo in DDS format


### PR DESCRIPTION
## Summary

Four bugs in the Papyrus layer, all related to the MCM effects page or denial cycle behaviour.

### `sla_pluginbase.psc` — blank text on every MCM effects entry
`SetOptionDefault` built its StorageUtil key using `numberOfOptions` (the counter *before* it was incremented) instead of the `option` parameter. Every option's default value was stored and looked up under the wrong ID, causing the MCM to display blank text for all effect entries.

### `sla_pluginbase.psc` — `DisablePlugin` never actually disabled update events
`DisablePlugin` called `SetPluginUpdateEvents(self, true)` — should be `false`. Plugins kept receiving update events after being disabled.

### `sla_pluginbase.psc` — MCM options stale after loading a save
`On_sla_Int_PlayerLoadsGame` did not call `ClearOptions`/`AddOptions`, so MCM option registrations were not refreshed on game load.

### `slaconfigscr.psc` — `ClearObjIntValuePrefix` clearing wrong object's storage
`StorageUtil.ClearObjIntValuePrefix(none, "SLAroused.MCM.OID.")` used `none` instead of `self`, clearing storage on the wrong object on MCM open and page reset.

### `sla_defaultplugin.psc` — denial cycle not re-established after save/load
The cycle guard only checked `cycleAux != 1`, missing the `cycleParam < 1.0` condition needed to re-establish a denial group when an actor's cycle param was reset on cosave load (see companion C++ PR #4).

## Test plan

- [ ] Open the Effects MCM page — option labels and values should no longer be blank
- [ ] Disable a plugin in MCM, verify it stops receiving update events
- [ ] Load a save with MCM open, verify option values are correct after load
- [ ] Verify denial cycle is re-established correctly after save/load for a denied actor

🤖 Generated with [Claude Code](https://claude.ai/claude-code)